### PR TITLE
Fix for Wow6432Node redirected add-ins

### DIFF
--- a/AddInScanEngine/AddInData.cs
+++ b/AddInScanEngine/AddInData.cs
@@ -27,6 +27,7 @@ namespace AddInSpy
     private string assemblyPath;
     private string loadBehavior;
     private string regHiveName;
+    private bool wow6432;
     private string assemblyName;
     private string clrVersion;
     private bool isObjectExposed;
@@ -39,7 +40,6 @@ namespace AddInSpy
     private bool status;
     private string statusDescription;
     private AppDomain currentDomain;
-    private AssemblyScanner scanner;
 
     public string HostName
     {
@@ -171,6 +171,18 @@ namespace AddInSpy
       {
         this.regHiveName = value;
       }
+    }
+
+    public bool Wow6432
+    {
+        get
+        {
+            return this.wow6432;
+        }
+        set
+        {
+            this.wow6432 = value;
+        }
     }
 
     public string AssemblyName
@@ -332,8 +344,7 @@ namespace AddInSpy
       if (this.hostName == "Outlook")
         this.outlookFormRegions = (string) null;
       this.currentDomain = AppDomain.CurrentDomain;
-      this.scanner = new AssemblyScanner();
-      this.currentDomain.ReflectionOnlyAssemblyResolve += new ResolveEventHandler(this.scanner.CurrentDomain_ReflectionOnlyAssemblyResolve);
+      this.currentDomain.ReflectionOnlyAssemblyResolve += new ResolveEventHandler(AssemblyScanner.CurrentDomain_ReflectionOnlyAssemblyResolve);
     }
 
     internal void SetInvalidRegistration()
@@ -529,7 +540,7 @@ namespace AddInSpy
         this.assemblyVersion = clickOnceInfo[1];
       }
       if (File.Exists(this.assemblyPath))
-        assemblyDetails = this.scanner.GetAssemblyInfo(this.assemblyPath, this.hostName, true);
+        assemblyDetails = AssemblyScanner.GetAssemblyInfo(this.assemblyPath, this.hostName, true);
       if (assemblyDetails != null && assemblyDetails.Length > 1)
       {
         this.assemblyName = assemblyDetails[0];
@@ -556,7 +567,7 @@ namespace AddInSpy
       this.assemblyPath = RegistryReader.GetInprocServerFromClsid(this.clsid, "CodeBase");
       if (this.assemblyPath != null && File.Exists(this.assemblyPath))
       {
-        string[] assemblyInfo = this.scanner.GetAssemblyInfo(this.assemblyPath, this.hostName, false);
+        string[] assemblyInfo = AssemblyScanner.GetAssemblyInfo(this.assemblyPath, this.hostName, false);
         this.assemblyName = assemblyInfo[0];
         this.clrVersion = assemblyInfo[1];
         this.supportedInterfaces = !scanManagedInterfaces ? (string) null : this.GetSupportedInterfaces(assemblyInfo);

--- a/AddInScanEngine/GridProxy.cs
+++ b/AddInScanEngine/GridProxy.cs
@@ -51,6 +51,7 @@ namespace AddInSpy
       this.dataTable.Columns.Add("DllPath");
       this.dataTable.Columns.Add("LoadBehavior");
       this.dataTable.Columns.Add("RegHive");
+      this.dataTable.Columns.Add("Wow6432", typeof (bool));
       this.dataTable.Columns.Add("AssemblyName");
       this.dataTable.Columns.Add("CLR_version");
       this.dataTable.Columns.Add("Exposed", typeof (bool));
@@ -88,6 +89,7 @@ namespace AddInSpy
           (object) addInData.AssemblyPath,
           (object) addInData.LoadBehavior,
           (object) addInData.RegHiveName,
+          (object) addInData.Wow6432,
           (object) addInData.AssemblyName,
           (object) addInData.ClrVersion,
           (object) addInData.IsObjectExposed,

--- a/AddInScanEngine/RegistryReader.cs
+++ b/AddInScanEngine/RegistryReader.cs
@@ -7,6 +7,7 @@
 using AddInSpy.Properties;
 using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
 
@@ -16,17 +17,31 @@ namespace AddInSpy
   {
     private static string formRegionRegKeyName = "Software\\Microsoft\\Office\\Outlook\\FormRegions";
 
-    internal static void GetAddInsRegHiveNames(RegistryKey regHive, string hostName, out string regHiveName, out string officeRegKeyName)
+    internal static void GetAddInsRegHiveNames(RegistryKey regHive, string hostName, out string regHiveName, List<string> officeRegKeyNames)
     {
       regHiveName = (string) null;
-      officeRegKeyName = (string) null;
       regHiveName = regHive != Registry.CurrentUser ? "HKLM" : "HKCU";
       if (hostName == "Visio")
-        officeRegKeyName = "Software\\Microsoft\\Visio\\Addins";
+      {
+          officeRegKeyNames.Add("Software\\Microsoft\\Visio\\Addins");
+
+          if (regHiveName == "HKLM")
+              officeRegKeyNames.Add("Software\\Wow6432Node\\Microsoft\\Visio\\Addins");
+      }
       else if (hostName == "Project")
-        officeRegKeyName = "Software\\Microsoft\\Office\\MS Project\\Addins";
+      {
+          officeRegKeyNames.Add("Software\\Microsoft\\Office\\MS Project\\Addins");
+
+          if (regHiveName == "HKLM")
+              officeRegKeyNames.Add("Software\\Wow6432Node\\Microsoft\\Office\\MS Project\\Addins");
+      }
       else
-        officeRegKeyName = "Software\\Microsoft\\Office\\" + hostName + "\\Addins";
+      {
+          officeRegKeyNames.Add("Software\\Microsoft\\Office\\" + hostName + "\\Addins");
+
+          if (regHiveName == "HKLM")
+              officeRegKeyNames.Add("Software\\Wow6432Node\\Microsoft\\Office\\" + hostName + "\\Addins");
+      }
     }
 
     internal static string GetInprocServerFromClsid(string clsid, string codeBase)

--- a/AddInSpy/AddInGridControl.cs
+++ b/AddInSpy/AddInGridControl.cs
@@ -26,6 +26,7 @@ namespace AddInSpy
     private DataGridViewTextBoxColumn DllPath;
     private DataGridViewTextBoxColumn LoadBehavior;
     private DataGridViewTextBoxColumn RegHive;
+    private DataGridViewCheckBoxColumn Wow6432;
     private DataGridViewTextBoxColumn AssemblyName;
     private DataGridViewTextBoxColumn CLR_version;
     private DataGridViewCheckBoxColumn Exposed;
@@ -77,6 +78,7 @@ namespace AddInSpy
       this.DllPath = new DataGridViewTextBoxColumn();
       this.LoadBehavior = new DataGridViewTextBoxColumn();
       this.RegHive = new DataGridViewTextBoxColumn();
+      this.Wow6432 = new DataGridViewCheckBoxColumn();
       this.AssemblyName = new DataGridViewTextBoxColumn();
       this.CLR_version = new DataGridViewTextBoxColumn();
       this.Exposed = new DataGridViewCheckBoxColumn();
@@ -98,7 +100,7 @@ namespace AddInSpy
       gridViewCellStyle1.SelectionForeColor = Color.Black;
       this.addInGrid.AlternatingRowsDefaultCellStyle = gridViewCellStyle1;
       this.addInGrid.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-      this.addInGrid.Columns.AddRange((DataGridViewColumn) this.Item, (DataGridViewColumn) this.Host, (DataGridViewColumn) this.Running, (DataGridViewColumn) this.Loaded, (DataGridViewColumn) this.Type, (DataGridViewColumn) this.FriendlyName, (DataGridViewColumn) this.ProgID, (DataGridViewColumn) this.CLSID, (DataGridViewColumn) this.Manifest, (DataGridViewColumn) this.DllPath, (DataGridViewColumn) this.LoadBehavior, (DataGridViewColumn) this.RegHive, (DataGridViewColumn) this.AssemblyName, (DataGridViewColumn) this.CLR_version, (DataGridViewColumn) this.Exposed, (DataGridViewColumn) this.Interfaces, (DataGridViewColumn) this.FormRegions, (DataGridViewColumn) this.VSTOR, (DataGridViewColumn) this.Installed, (DataGridViewColumn) this.PubVer, (DataGridViewColumn) this.Status2, (DataGridViewColumn) this.Status, (DataGridViewColumn) this.StatusDescription);
+      this.addInGrid.Columns.AddRange((DataGridViewColumn) this.Item, (DataGridViewColumn) this.Host, (DataGridViewColumn) this.Running, (DataGridViewColumn) this.Loaded, (DataGridViewColumn) this.Type, (DataGridViewColumn) this.FriendlyName, (DataGridViewColumn) this.ProgID, (DataGridViewColumn) this.CLSID, (DataGridViewColumn) this.Manifest, (DataGridViewColumn) this.DllPath, (DataGridViewColumn) this.LoadBehavior, (DataGridViewColumn) this.RegHive, (DataGridViewColumn) this.Wow6432, (DataGridViewColumn) this.AssemblyName, (DataGridViewColumn) this.CLR_version, (DataGridViewColumn) this.Exposed, (DataGridViewColumn) this.Interfaces, (DataGridViewColumn) this.FormRegions, (DataGridViewColumn) this.VSTOR, (DataGridViewColumn) this.Installed, (DataGridViewColumn) this.PubVer, (DataGridViewColumn) this.Status2, (DataGridViewColumn) this.Status, (DataGridViewColumn) this.StatusDescription);
       gridViewCellStyle2.Alignment = DataGridViewContentAlignment.MiddleLeft;
       gridViewCellStyle2.BackColor = SystemColors.Window;
       gridViewCellStyle2.Font = new Font("Microsoft Sans Serif", 8.25f, FontStyle.Regular, GraphicsUnit.Point, (byte) 0);
@@ -148,6 +150,9 @@ namespace AddInSpy
       this.RegHive.DataPropertyName = "RegHive";
       componentResourceManager.ApplyResources((object) this.RegHive, "RegHive");
       this.RegHive.Name = "RegHive";
+      this.Wow6432.DataPropertyName = "Wow6432";
+      componentResourceManager.ApplyResources((object)this.Wow6432, "Wow6432");
+      this.Wow6432.Name = "Wow6432";
       this.AssemblyName.DataPropertyName = "AssemblyName";
       componentResourceManager.ApplyResources((object) this.AssemblyName, "AssemblyName");
       this.AssemblyName.Name = "AssemblyName";

--- a/AddInSpy/AddInGridControl.resx
+++ b/AddInSpy/AddInGridControl.resx
@@ -492,4 +492,22 @@
   <data name="addInGrid.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="&gt;&gt;Wow6432.Name" xml:space="preserve">
+    <value>Wow6432</value>
+  </data>
+  <data name="&gt;&gt;Wow6432.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Wow6432.Name" xml:space="preserve">
+    <value>Wow6432</value>
+  </data>
+  <data name="Wow6432.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Wow6432.Width" type="System.Int32, mscorlib">
+    <value>60</value>
+  </data>
+  <data name="Wow6432.HeaderText" xml:space="preserve">
+    <value>Wow6432</value>
+  </data>
 </root>

--- a/AddInSpy/AddInSpy.csproj
+++ b/AddInSpy/AddInSpy.csproj
@@ -109,7 +109,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AddInDataControl.resx" />
-    <EmbeddedResource Include="AddInGridControl.resx" />
+    <EmbeddedResource Include="AddInGridControl.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx" />
   </ItemGroup>
   <ItemGroup>

--- a/AddInSpy/AddInSpyWindow.xaml.cs
+++ b/AddInSpy/AddInSpyWindow.xaml.cs
@@ -338,6 +338,9 @@ namespace AddInSpy
 
     private void AddInGrid_CellContentDoubleClick(object sender, DataGridViewCellEventArgs e)
     {
+      if (e.RowIndex == -1)
+          return;
+
       DataRow dataRow = this.controller.GridProxy.AddInDataTable.Rows[e.RowIndex];
       DataTable dataTable = new DataTable();
       dataTable.Columns.Add(AppResources.SINGLE_ROW_TABLE_ITEM_COLUMN);

--- a/AddInSpy/addinspywindow.xaml
+++ b/AddInSpy/addinspywindow.xaml
@@ -1,115 +1,116 @@
-<Window x:Class="AddInSpy.AddInSpyWindow"
+<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:uc="clr-namespace:AddInSpy"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" x:Class="AddInSpy.AddInSpyWindow"
         Closing="Window_Closing" Title="AddInSpy" Height="720" Width="1270">
-  <Grid Name="outerGrid" Row="1" VerticalAlignment="Top">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="28"/>
-      <RowDefinition Height="*"/>
-      <RowDefinition Height="28"/>
-    </Grid.RowDefinitions>
-    <Grid Name="innerGrid" Row="0">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="44"/>
-        <ColumnDefinition Width="138"/>
-        <ColumnDefinition Width="44"/>
-        <ColumnDefinition Width="138"/>
-        <ColumnDefinition Width="72"/>
-        <ColumnDefinition Width="86"/>
-        <ColumnDefinition Width="52"/>
-        <ColumnDefinition Width="138"/>
-        <ColumnDefinition Width="72"/>
-        <ColumnDefinition Width="72"/>
-      </Grid.ColumnDefinitions>
-      <Label Name="labelHosts" Grid.Column="0" Margin="1,2,1,1"/>
-      <uc:CheckedComboControl x:Name="selectedHosts" Grid.Row="0" Grid.Column="1" Margin="1,3,1,1"/>
-      <Label Name="labelScans" Grid.Column="2" Margin="1,2,1,1"/>
-      <uc:CheckedComboControl x:Name="selectedScans" Grid.Row="0" Grid.Column="3" Margin="1,3,1,1"/>
-      <Button Click="buttonRefresh_Click" Name="buttonRefresh" Grid.Column="4" Height="24" Width="70"
-              Margin="1,1,1,1">
-        <Grid>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="16"/>
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <Image Grid.Column="0" Source="/AddInSpy;component/Images/Refresh.png"/>
-          <TextBlock Name="buttonRefreshText" Grid.Column="1"/>
-        </Grid>
-      </Button>
-      <CheckBox Click="autoRefresh_Click" Name="autoRefresh" Grid.Column="5" Height="24" Margin="1,7,1,1"
-                FlowDirection="RightToLeft" IsChecked="false"/>
-      <Label Name="labelReport" Grid.Column="6" Margin="1,2,1,1"/>
-      <uc:CheckedComboControl x:Name="selectedReport" Grid.Row="0" Grid.Column="7" Margin="1,3,1,1"/>
-      <Button Click="buttonReport_Click" Name="buttonReport" Grid.Column="8" Height="24" Width="70"
-              Margin="1,1,1,1">
-        <Grid>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="16"/>
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <Image Grid.Column="0" Source="/AddInSpy;component/Images/Report.png"/>
-          <TextBlock Name="buttonReportText" Grid.Column="1"/>
-        </Grid>
-      </Button>
-      <Button Click="buttonHelp_Click" Name="buttonHelp" Grid.Column="9" Height="24" Width="70" Margin="1,1,1,1">
-        <Grid>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="16"/>
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <Image Grid.Column="0" Source="/AddInSpy;component/Images/Help.png"/>
-          <TextBlock Name="buttonHelpText" Grid.Column="1"/>
-        </Grid>
-      </Button>
-    </Grid>
-    <uc:WfGridProxyControl x:Name="gridControl" Grid.Row="1" Margin="1,1,1,1" HorizontalAlignment="Left" Height="648"
-                           Width="1135"/>
-    <StatusBar Name="statusBar" Grid.Row="2" VerticalAlignment="Bottom">
-      <ItemsControl.ItemsPanel>
-        <ItemsPanelTemplate>
-          <Grid>
+    <Grid x:Name="outerGrid" Grid.Row="1" VerticalAlignment="Top">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="28"/>
+        </Grid.RowDefinitions>
+        <Grid x:Name="innerGrid" Grid.Row="0">
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="44"/>
+                <ColumnDefinition Width="138"/>
+                <ColumnDefinition Width="44"/>
+                <ColumnDefinition Width="138"/>
+                <ColumnDefinition Width="72"/>
+                <ColumnDefinition Width="86"/>
+                <ColumnDefinition Width="52"/>
+                <ColumnDefinition Width="138"/>
+                <ColumnDefinition Width="72"/>
+                <ColumnDefinition Width="72"/>
             </Grid.ColumnDefinitions>
-          </Grid>
-        </ItemsPanelTemplate>
-      </ItemsControl.ItemsPanel>
-      <StatusBarItem Grid.Column="0">
-        <TextBlock Name="statusMachine"/>
-      </StatusBarItem>
-      <Separator Grid.Column="1" Background="DarkGray" Width="1" Height="20"/>
-      <StatusBarItem Grid.Column="2">
-        <TextBlock Name="statusUser"/>
-      </StatusBarItem>
-      <Separator Grid.Column="3" Background="DarkGray" Width="1" Height="20"/>
-      <StatusBarItem Grid.Column="4">
-        <TextBlock Name="statusOS"/>
-      </StatusBarItem>
-      <Separator Grid.Column="5" Background="DarkGray" Width="1" Height="20"/>
-      <StatusBarItem Grid.Column="6">
-        <TextBlock Name="statusVstoSuppressDisplayAlerts" Text="VSTO_SUPPRESSDISPLAYALERTS="/>
-      </StatusBarItem>
-      <Separator Grid.Column="7" Background="DarkGray" Width="1" Height="20"/>
-      <StatusBarItem Grid.Column="8">
-        <TextBlock Name="statusVstoLogAlerts" Text="VSTO_LOGALERTS="/>
-      </StatusBarItem>
-      <Separator Grid.Column="9" Background="DarkGray" Width="1" Height="20"/>
-      <StatusBarItem Grid.Column="10">
-        <TextBlock Name="statusAddInsFound"/>
-      </StatusBarItem>
-      <Separator Grid.Column="11" Background="DarkGray" Width="1" Height="20"/>
-    </StatusBar>
-  </Grid>
+            <Label x:Name="labelHosts" Grid.Column="0" Margin="1,2,1,1"/>
+            <uc:CheckedComboControl x:Name="selectedHosts" Grid.Row="0" Grid.Column="1" Margin="1,3,1,1"/>
+            <Label x:Name="labelScans" Grid.Column="2" Margin="1,2,1,1"/>
+            <uc:CheckedComboControl x:Name="selectedScans" Grid.Row="0" Grid.Column="3" Margin="1,3,1,1"/>
+            <Button Click="buttonRefresh_Click" x:Name="buttonRefresh" Grid.Column="4" Height="24" Width="70"
+				Margin="1,1,1,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="16"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Image Grid.Column="0" Source="/AddInSpy;component/Images/Refresh.png"/>
+                    <TextBlock x:Name="buttonRefreshText" Grid.Column="1"/>
+                </Grid>
+            </Button>
+            <CheckBox Click="autoRefresh_Click" x:Name="autoRefresh" Grid.Column="5" Height="24" Margin="1,7,1,1"
+				FlowDirection="RightToLeft" IsChecked="false"/>
+            <Label x:Name="labelReport" Grid.Column="6" Margin="1,2,1,1"/>
+            <uc:CheckedComboControl x:Name="selectedReport" Grid.Row="0" Grid.Column="7" Margin="1,3,1,1"/>
+            <Button Click="buttonReport_Click" x:Name="buttonReport" Grid.Column="8" Height="24" Width="70"
+				Margin="1,1,1,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="16"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Image Grid.Column="0" Source="/AddInSpy;component/Images/Report.png"/>
+                    <TextBlock x:Name="buttonReportText" Grid.Column="1"/>
+                </Grid>
+            </Button>
+            <Button Click="buttonHelp_Click" x:Name="buttonHelp" Grid.Column="9" Height="24" Width="70" Margin="1,1,1,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="16"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Image Grid.Column="0" Source="/AddInSpy;component/Images/Help.png"/>
+                    <TextBlock x:Name="buttonHelpText" Grid.Column="1"/>
+                </Grid>
+            </Button>
+        </Grid>
+        <uc:WfGridProxyControl x:Name="gridControl" Grid.Row="1" Margin="1,1,1,1" HorizontalAlignment="Left" Height="648"
+			Width="1135"/>
+        <StatusBar x:Name="statusBar" Grid.Row="2" VerticalAlignment="Bottom">
+            <StatusBar.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                    </Grid>
+                </ItemsPanelTemplate>
+            </StatusBar.ItemsPanel>
+            <StatusBarItem Grid.Column="0">
+                <TextBlock x:Name="statusMachine"/>
+            </StatusBarItem>
+            <Separator Grid.Column="1" Background="DarkGray" Width="1" Height="20"/>
+            <StatusBarItem Grid.Column="2">
+                <TextBlock x:Name="statusUser"/>
+            </StatusBarItem>
+            <Separator Grid.Column="3" Background="DarkGray" Width="1" Height="20"/>
+            <StatusBarItem Grid.Column="4">
+                <TextBlock x:Name="statusOS"/>
+            </StatusBarItem>
+            <Separator Grid.Column="5" Background="DarkGray" Width="1" Height="20"/>
+            <StatusBarItem Grid.Column="6">
+                <TextBlock x:Name="statusVstoSuppressDisplayAlerts" Text="VSTO_SUPPRESSDISPLAYALERTS="/>
+            </StatusBarItem>
+            <Separator Grid.Column="7" Background="DarkGray" Width="1" Height="20"/>
+            <StatusBarItem Grid.Column="8">
+                <TextBlock x:Name="statusVstoLogAlerts" Text="VSTO_LOGALERTS="/>
+            </StatusBarItem>
+            <Separator Grid.Column="9" Background="DarkGray" Width="1" Height="20"/>
+            <StatusBarItem Grid.Column="10">
+                <TextBlock x:Name="statusAddInsFound"/>
+            </StatusBarItem>
+            <Separator Grid.Column="11" Background="DarkGray" Width="1" Height="20"/>
+        </StatusBar>
+    </Grid>
 </Window>


### PR DESCRIPTION
HKLM-registered (installed for all users) add-ins are registered differently when using a 32-bit version of Office on 64-bit Windows. This PR adds the ability to enumerate through `Wow6432Node` redirected add-ins under `HKLM`.

> Unlike the HKCU registry hive, the HKLM registry hive for Office add-ins is redirected on a 64-bit Windows OS. So if you are trying to register an add-in with 32-bit version of Office running on a 64-bit OS, the add-ins registry will be under the WOW6432Node. The 32-bit Office running on 64-bit OS will always load the add-ins listed under this key.

http://blogs.msdn.com/b/vsto/archive/2010/03/08/deploying-your-vsto-add-ins-to-all-users-saurabh-bhatia.aspx

Also included is a fix so that an error is not thrown when the result grid's header is double clicked.

Example result grid with this PR's changes:
![screenshot 2015-09-15 20 32 14](https://cloud.githubusercontent.com/assets/1616060/9894603/0de5217c-5beb-11e5-9bc3-012830604fa8.png)
